### PR TITLE
Fix typo "graceperiod" -> "grace_period"

### DIFF
--- a/users/googleauth.sls
+++ b/users/googleauth.sls
@@ -74,7 +74,7 @@ users_googleauth-pam-{{ svc }}-{{ name }}:
 {%- else %}
     - pattern: '^(@include[ \t]*common-auth)'
 {%- endif %}
-{% set graceperiod = 'graceperiod=' + grains.get('google_2fa', {}).get('graceperiod', '0') | string %}
+{% set graceperiod = 'grace_period=' + grains.get('google_2fa', {}).get('graceperiod', '0') | string %}
     - repl: '{{ repl }} {{ graceperiod }}\n\1'
     - unless: grep pam_google_authenticator.so /etc/pam.d/{{ svc }}
     - backup: .bak


### PR DESCRIPTION
Fixes error:
  sshd(pam_google_authenticator)[1234]: Unrecognized option "graceperiod=0"

See also documentation:
- https://github.com/google/google-authenticator-libpam